### PR TITLE
Implement grid, remove mid and right classes

### DIFF
--- a/force-app/main/default/lwc/gnalGenericLinkComponent/gnalGenericLinkComponent.css
+++ b/force-app/main/default/lwc/gnalGenericLinkComponent/gnalGenericLinkComponent.css
@@ -1,0 +1,53 @@
+.icon--appointment {
+  --slds-c-icon-color-background: #4e1e2d;
+}
+
+:host lightning-card.card {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+:host lightning-card.card .slds-card__header {
+  padding: 0.75rem 1rem;
+}
+
+:host lightning-card.card .slds-card__header-title .slds-truncate {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+:host lightning-card.card .slds-card__body {
+  padding-top: 0.25rem;
+}
+
+.gnal-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  width: 100%;
+}
+
+.gnal-row:hover {
+  background-color: #f3f6fb;
+}
+
+.gnal-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.gnal-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.gnal-right {
+  justify-self: end;
+  white-space: nowrap;
+  text-align: right;
+}

--- a/force-app/main/default/lwc/gnalGenericLinkComponent/gnalGenericLinkComponent.html
+++ b/force-app/main/default/lwc/gnalGenericLinkComponent/gnalGenericLinkComponent.html
@@ -1,0 +1,87 @@
+<template>
+  <lightning-card title={title} class="gnal-card">
+    <div class="slds-p-horizontal_small">
+      <template lwc:if={description}>
+        <p class="slds-text-body_regular slds-m-bottom_small">{description}</p>
+      </template>
+
+      <ul role="list">
+        <template for:each={normalizedLinks} for:item="l">
+          <li key={l.key} class="slds-item" role="listitem">
+            <template lwc:if={isAuthenticated}>
+              <a
+                class="slds-text-link_reset gnal-row gnal-link"
+                data-url={l.url}
+                onclick={handleNavigate}
+                aria-label={l.ariaLabel}
+                title={l.ariaLabel}
+              >
+                <template lwc:if={l.icon}>
+                  <lightning-icon
+                    class="icon--appointment"
+                    icon-name={l.icon}
+                    alternative-text={l.label}
+                    title={l.label}
+                    size="small"
+                  ></lightning-icon>
+                </template>
+
+                <div class="gnal-text">
+                  <div class="gnal-primary">{l.label}</div>
+
+                  <template lwc:if={l.subText}>
+                    <div class="gnal-sub slds-text-color_weak slds-text-body_small">
+                      {l.subText}
+                    </div>
+                  </template>
+                </div>
+
+                <template lwc:if={l.rightText}>
+                  <span class="gnal-right slds-text-body_small slds-text-color_weak">{l.rightText}</span>
+                </template>
+              </a>
+            </template>
+
+            <template lwc:else>
+              <div class="gnal-row gnal-item-disabled" aria-disabled="true">
+                <template lwc:if={l.icon}>
+                  <lightning-icon
+                    class="icon--appointment"
+                    icon-name={l.icon}
+                    alternative-text={l.label}
+                    title={l.label}
+                    size="small"
+                  ></lightning-icon>
+                </template>
+
+                <div class="gnal-text">
+                  <div class="gnal-primary">{l.label}</div>
+
+                  <template lwc:if={l.subText}>
+                    <div class="gnal-sub slds-text-color_weak slds-text-body_small">
+                      {l.subText}
+                    </div>
+                  </template>
+                </div>
+
+                <template lwc:if={l.rightText}>
+                  <span class="gnal-right slds-text-body_small slds-text-color_weak">{l.rightText}</span>
+                </template>
+              </div>
+            </template>
+          </li>
+        </template>
+      </ul>
+
+      <hr class="tile-divider" />
+
+      <template lwc:if={footerUrlResolved}>
+        <div class="slds-m-top_small slds-text-align_center">
+          <a class="slds-text-link" data-url={footerUrlResolved} onclick={handleLearnMore}>
+            {footerLabelResolved}
+          </a>
+        </div>
+      </template>
+    </div>
+  </lightning-card>
+</template>


### PR DESCRIPTION
Refactor `gnalGenericLinkComponent` to use CSS Grid, removing the `mid` and `right` utility classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c78d05c-2464-4a4c-b7fc-49527556fe63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c78d05c-2464-4a4c-b7fc-49527556fe63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

